### PR TITLE
feature/save-input: save markdown form input in localStorage

### DIFF
--- a/src/authClient.js
+++ b/src/authClient.js
@@ -1,4 +1,4 @@
-import { AUTH_LOGIN } from 'admin-on-rest';
+import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_CHECK } from 'admin-on-rest';
 import { API_URL } from './config'
 
 export default (type, params) => {
@@ -19,6 +19,13 @@ export default (type, params) => {
             .then(({ token }) => {
                 localStorage.setItem('token', token)
             });
+    }
+    if (type === AUTH_LOGOUT) {
+        localStorage.removeItem('token');
+        return Promise.resolve();
+    }
+    if (type === AUTH_CHECK) {
+        return localStorage.getItem('token') ? Promise.resolve() : Promise.reject();
     }
     return Promise.resolve();
 }

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -1,13 +1,11 @@
 import React, { PropTypes } from 'react'
 import { 
     List, Edit, Create, Datagrid, TextField, EditButton, 
-    DisabledInput, LongTextInput, SimpleForm, 
-    TextInput
 } from 'admin-on-rest/lib/mui'
-import MarkdownInput from './MarkdownInput'
 import DeleteButton from './DeleteButton'
 import Chip from 'material-ui/Chip'
 import get from 'lodash.get'
+import ArticleForm from './ArticleForm'
 
 const MultipleTagField = ({ source, record = {} }) => {
     const tags = get(record, source)
@@ -42,28 +40,17 @@ const ArticleTitle = ({ record }) => {
     return <span>Article {record ? `"${record.title}"` : ''}</span>;
 };
 
-export const ArticleEdit = (props) => (
-    <Edit title={<ArticleTitle />} {...props}>
-        <SimpleForm>
-            <DisabledInput source="id" />
-            <TextInput source="title" />
-            <TextInput source="summary" />
-            <TextInput source="tagNames" />
-            <LongTextInput source="markdown" />
-            <MarkdownInput source="markdown" />
-        </SimpleForm>
-    </Edit>
-);
+
+export const ArticleEdit = (props) => {
+    return (
+        <Edit title={<ArticleTitle />} {...props}>
+            <ArticleForm />
+        </Edit>
+    )
+}
 
 export const ArticleCreate = (props) => (
     <Create {...props}>
-        <SimpleForm>
-            <TextInput source="slug" />
-            <TextInput source="title" />
-            <TextInput source="summary" />
-            <TextInput source="tagNames" />
-            <LongTextInput source="markdown" />
-            <MarkdownInput source="markdown" />
-        </SimpleForm>
+        <ArticleForm />
     </Create>
 );

--- a/src/components/ArticleForm.js
+++ b/src/components/ArticleForm.js
@@ -1,0 +1,30 @@
+import React, {Component} from 'react'
+import { 
+    DisabledInput, SimpleForm, TextInput
+} from 'admin-on-rest/lib/mui'
+import MarkdownInput from './MarkdownInput'
+import MarkdownDisplay from './MarkdownDisplay'
+import { change } from 'redux-form';
+import { connect } from 'react-redux'
+
+class ArticleForm extends Component {
+    componentDidMount() {
+        const storageId = this.props.record.id || 'new'
+        const initialMarkdown = localStorage.getItem(storageId) || this.props.record.markdown
+        this.props.dispatch(change('record-form', 'markdown', initialMarkdown))
+    }
+    render(){
+        return (
+            <SimpleForm {...this.props}>
+                <DisabledInput source="id" />
+                <TextInput source="title" />
+                <TextInput source="summary" />
+                <TextInput source="tagNames" />
+                <MarkdownInput source="markdown"/>
+                <MarkdownDisplay source="markdown" />
+            </SimpleForm>
+        )
+    }
+}
+
+export default connect()(ArticleForm)

--- a/src/components/MarkdownDisplay.js
+++ b/src/components/MarkdownDisplay.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Field } from 'redux-form';
+import Markdown from './Markdown';
+
+const renderTextField = ({ input, label, meta: { touched, error }, ...custom }) => (
+    <Markdown>
+        {input.value}
+    </Markdown>
+);
+const MarkdownDisplay = () => (
+    <span>
+        <Field name="markdown" component={renderTextField} label="markdown" />
+    </span>
+);
+
+export default MarkdownDisplay

--- a/src/components/MarkdownInput.js
+++ b/src/components/MarkdownInput.js
@@ -1,16 +1,34 @@
-import React from 'react'
-import { Field } from 'redux-form';
-import Markdown from './Markdown';
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
 
-const renderTextField = ({ input, label, meta: { touched, error }, ...custom }) => (
-    <Markdown>
-        {input.value}
-    </Markdown>
-);
-const MarkdownInput = () => (
-    <span>
-        <Field name="markdown" component={renderTextField} label="markdown" />
-    </span>
-);
+class MarkdownInput extends Component {
+    constructor(props){
+        super(props)
+        this.onMarkdownChange = this.onMarkdownChange.bind(this)
+    }
+    onMarkdownChange(e, newValue, inputOnChange) {
+        inputOnChange(newValue)
+        const { record: { id } } = this.props
+        const storageId = id || 'new'
+        console.log(`saving markdown in ${storageId}`)
+        localStorage.setItem(storageId, newValue)
+    }
+    render() {
+        const { input, label, meta: { touched, error } } = this.props
+        const onChange = (e, newValue) => this.onMarkdownChange(e, newValue, input.onChange)
+        const inputProps = {...input, onChange}
+        return (
+            <TextField
+                multiLine={true}
+                hintText={label}
+                floatingLabelText={label}
+                errorText={touched && error}
+                {...inputProps} />
+        )
+    }
+}
+MarkdownInput.defaultProps = {
+    addField: true
+}
 
 export default MarkdownInput


### PR DESCRIPTION
### Change Summary
- add ability to save markdown form input in localStorage so it does not accidently get lost